### PR TITLE
Fix menu keybind not working under Proton

### DIFF
--- a/ImGui DirectX 11 Kiero Hook/main.cpp
+++ b/ImGui DirectX 11 Kiero Hook/main.cpp
@@ -4630,10 +4630,13 @@ HRESULT __stdcall hkPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT 
 			return decltype(&hkPresent)(oPresent)(pSwapChain, SyncInterval, Flags);
 	}
 
-	if (GetAsyncKeyState(OpenKeybind) & 1)
-	{
-		open = !open;
-	}
+  static bool openKeyWasDown = false;
+  bool openKeyIsDown = (GetAsyncKeyState(OpenKeybind) & 0x8000) != 0;
+  if (openKeyIsDown && !openKeyWasDown)
+  {
+      open = !open;
+  }
+  openKeyWasDown = openKeyIsDown;
 
 	static bool prev = false;
 


### PR DESCRIPTION
This PR fixes #61 by using the low bit of `GetAsyncKeyState(OpenKeybind)` rather than the high bit, which does not appear to be reported reliably under Wine/Proton.

The Microsoft documentation for `GetAsyncKeyState` notes that the low bit is not guaranteed to be reliable on Windows. I do not currently have access to a native Windows installation to verify the change there, so testing on Windows would be appreciated.

I verified that this fixes the issue on Debian 12 using Proton GE 10.34, GE 10.27, GE 9.8, and Proton Experimental, as described in the linked issue.